### PR TITLE
Special treatment for gamelan and adler collectons in the filter query

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -182,6 +182,8 @@ class ApplicationController < ActionController::Base
       fq_forum += '))'
 
       fq_forum_special =
+        # gamelan does not care about status_ssi
+        '(project_id_ssi:' + ssc[:gamelan].to_s + ' OR ' +
 
       # non-JSTOR filters
       fq_dlxs = '(-active_fedora_model_ssi:"Page" AND

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,8 +112,7 @@ class ApplicationController < ActionController::Base
 
       # JSTOR Forum filters
       fq_forum = '(id:ss* AND
-        (status_ssi:"Published" OR publish_to_portal_tesim:*) AND
-        -adler_status:"Suppress for portal" AND
+        status_ssi:"Published" AND
         -project_id_ssi:('
       fq_forum += [   # comment out any collections you want to display
         #ssc[:adler],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -209,7 +209,7 @@ class ApplicationController < ActionController::Base
         # dlxs[:scott],
         # dlxs[:sea],
         # dlxs[:witchcraft],
-        dlxs[:wordsworth]
+        dlxs[:words]
       ].join(' ')
       fq_dlxs += '))'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,6 +184,8 @@ class ApplicationController < ActionController::Base
       fq_forum_special =
         # gamelan does not care about status_ssi
         '(project_id_ssi:' + ssc[:gamelan].to_s + ' OR ' +
+        # adler does not use status_ssi but has it's own status
+        '(project_id_ssi:' + ssc[:adler].to_s + ' AND publish_to_portal_tesim:*))'
 
       # non-JSTOR filters
       fq_dlxs = '(-active_fedora_model_ssi:"Page" AND

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::Base
         ssc[:dynkin],
         #ssc[:eleusis],
         #ssc[:fallout],
-        #ssc[:gamelan],
+        #ssc[:gamelan],   -- forced
         #ssc[:gems],
         ssc[:harrisson],
         #ssc[:hill],
@@ -185,6 +185,8 @@ class ApplicationController < ActionController::Base
       ].join(' OR ')
       fq_forum += '))'
 
+      fq_forum_force = 'project_id_ssi:' + ssc[:gamelan]
+
       # non-JSTOR filters
       fq_dlxs = '(-active_fedora_model_ssi:"Page" AND
         id:('
@@ -217,7 +219,7 @@ class ApplicationController < ActionController::Base
       ].join(' ')
       fq_other += ')'
 
-      fq = '(' + [fq_dlxs, fq_forum, fq_other].join(' OR ').gsub(/\s+/, " ") + ')'
+      fq = '(' + [fq_dlxs, fq_forum, fq_forum_force, fq_other].join(' OR ').gsub(/\s+/, " ") + ')'
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -181,7 +181,7 @@ class ApplicationController < ActionController::Base
       ].join(' OR ')
       fq_forum += '))'
 
-      fq_forum_force = 'project_id_ssi:' + ssc[:gamelan]
+      fq_forum_special =
 
       # non-JSTOR filters
       fq_dlxs = '(-active_fedora_model_ssi:"Page" AND
@@ -209,7 +209,7 @@ class ApplicationController < ActionController::Base
       ].join(' ')
       fq_dlxs += '))'
 
-      fq = '(' + [fq_dlxs, fq_forum, fq_forum_force].join(' OR ').gsub(/\s+/, " ") + ')'
+      fq = '(' + [fq_dlxs, fq_forum, fq_forum_special].join(' OR ').gsub(/\s+/, " ") + ')'
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,10 +95,7 @@ class ApplicationController < ActionController::Base
       scott: "scott*",			    # Scottsboro Trials Collection
       sea: "sea*",			        # Southeast Asia Visions
       witchcraft: "witchcraft*",# Digital Witchcraft Collection
-    }
-
-    other = {
-      wordsworth: '"Wordsworth Collection"'
+      words: "words*"           # Wordsworth Collection
     }
 
     if environment == 'development'
@@ -208,18 +205,12 @@ class ApplicationController < ActionController::Base
         # dlxs[:sat],
         # dlxs[:scott],
         # dlxs[:sea],
-        # dlxs[:witchcraft]
+        # dlxs[:witchcraft],
+        dlxs[:wordsworth]
       ].join(' ')
       fq_dlxs += '))'
 
-      # dlxs collections that have collection_tesim but no id prefix
-      fq_other = 'collection_tesim:('
-      fq_other += [
-        other[:wordsworth]
-      ].join(' ')
-      fq_other += ')'
-
-      fq = '(' + [fq_dlxs, fq_forum, fq_forum_force, fq_other].join(' OR ').gsub(/\s+/, " ") + ')'
+      fq = '(' + [fq_dlxs, fq_forum, fq_forum_force].join(' OR ').gsub(/\s+/, " ") + ')'
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,7 +115,7 @@ class ApplicationController < ActionController::Base
         status_ssi:"Published" AND
         -project_id_ssi:('
       fq_forum += [   # comment out any collections you want to display
-        #ssc[:adler],
+        ssc[:adler],  # special - see below
         #ssc[:adwhite],
         #ssc[:aerial],
         ssc[:ahearn],
@@ -135,7 +135,7 @@ class ApplicationController < ActionController::Base
         ssc[:dynkin],
         #ssc[:eleusis],
         #ssc[:fallout],
-        #ssc[:gamelan],   -- forced
+        ssc[:gamelan],   # special - see below
         #ssc[:gems],
         ssc[:harrisson],
         #ssc[:hill],


### PR DESCRIPTION
Add Wordsworth id prefix. 
Ignore status_ssi for gamelan. 
Use adler status fields only for adler.

adler records have either publish_to_portal_tesim or adler_status but not both. publish_to_portal_tesim is always 1 and adler_status is always "Suppress for portal" - no need to use both.
