### PR TITLE
Digcoll 1671 - allow viewing multi-images in dev

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,6 @@ class ApplicationController < ActionController::Base
     dlxs = {
       bol: "bol*",			        # Alfredo Montalvo Bolivian Digital Pamphlets Collection
       chla: "chla*",			      # Core Historical Literature of Agriculture
-      cmip: "cmip*",			      # Cornell Modern Indonesia Collection
       cooper: "cooper*",		    # Cooper Bridge Plan Collection
       ezra: "ezra*",			      # Ezra Cornell Papers
       flo: "flo*",			        # Language of Flowers
@@ -192,7 +191,6 @@ class ApplicationController < ActionController::Base
       fq_dlxs += [  # include these dlxs collections
         dlxs[:bol],
         dlxs[:chla],
-        # dlxs[:cmip],
         # dlxs[:cooper],
         # dlxs[:ezra],
         dlxs[:flo],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
       hearth: "hearth*",		    # Home Economics Archive: Research
       hivebees: "hivebees*",    # Hive and the Honeybee
       hunt: "hunt*",			      # Huntington Free Library Native American Collection
-      izq: "izq*",			        # History of the Left in Latin America
+      izquierda: "izquierda*",  # History of the Left in Latin America
       liber: "liber*",		    	# Liberian Law Collection
       may: "may*",			        # Samuel J. May Anti-Slavery Collection
       nur: "nur*",			        # Donovan Nuremberg Trials Collection
@@ -197,7 +197,7 @@ class ApplicationController < ActionController::Base
         dlxs[:hearth],
         dlxs[:hivebees],
         dlxs[:hunt],
-        # dlxs[:izq],
+        # dlxs[:izquierda],
         # dlxs[:liber],
         # dlxs[:may],
         # dlxs[:nur],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,7 +90,6 @@ class ApplicationController < ActionController::Base
       liber: "liber*",		    	# Liberian Law Collection
       may: "may*",			        # Samuel J. May Anti-Slavery Collection
       nur: "nur*",			        # Donovan Nuremberg Trials Collection
-      regmi: "regmi*",		      # Regmi Research Series
       sat: "sat*",			        # Trial Pamphlets Collection
       scott: "scott*",			    # Scottsboro Trials Collection
       sea: "sea*",			        # Southeast Asia Visions
@@ -204,7 +203,6 @@ class ApplicationController < ActionController::Base
         # dlxs[:liber],
         # dlxs[:may],
         # dlxs[:nur],
-        # dlxs[:regmi],
         # dlxs[:sat],
         # dlxs[:scott],
         # dlxs[:sea],

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -520,12 +520,20 @@ def has_collection_selected?
   end
 end
 
-
 def asset_visible?(document)
   # eid = id.sub(':', '\:')
   if document.id.present?
-    eid = document.id
-    fq = URI.escape(@fq)
+    eid = document.id.sub(':', '\:')
+    environment = ENV['RAILS_ENV']
+    if environment == 'development'
+      # see app/controllers/application_controller.rb:100
+      fqa = ['-active_fedora_model_ssi:"Page"',
+        '-solr_loader_tesim:"eCommons"']
+      fq = fqa.join(' AND ')
+    else
+      fq = @fq
+    end
+    fq = URI.escape(fq)
     response = JSON.parse(HTTPClient.get_content("#{ENV['SOLR_URL']}/select?q=id:#{eid}&fq=#{fq}&fl=id&wt=json&indent=true&rows=1")).with_indifferent_access
     count = response['response']['numFound']
     count > 0
@@ -533,7 +541,5 @@ def asset_visible?(document)
     false
   end
 end
-
-
 
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -527,6 +527,7 @@ def asset_visible?(document)
     environment = ENV['RAILS_ENV']
     if environment == 'development'
       # see app/controllers/application_controller.rb:100
+      # leave out the work_sequence_isi:[2 TO *] clauses to allow viewing multi-image
       fqa = ['-active_fedora_model_ssi:"Page"',
         '-solr_loader_tesim:"eCommons"']
       fq = fqa.join(' AND ')

--- a/app/views/catalog/_multi_images.html.erb
+++ b/app/views/catalog/_multi_images.html.erb
@@ -7,7 +7,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 					    <img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -24,7 +24,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 							<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -59,7 +59,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -76,7 +76,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -93,7 +93,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>


### PR DESCRIPTION
Leave multi-images out of the index pages, but allow viewing all other images once the key image is selected.