### PR TITLE
Digcoll 1671 - allow viewing multi-images in dev (#1165)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,18 +79,16 @@ class ApplicationController < ActionController::Base
     dlxs = {
       bol: "bol*",			        # Alfredo Montalvo Bolivian Digital Pamphlets Collection
       chla: "chla*",			      # Core Historical Literature of Agriculture
-      cmip: "cmip*",			      # Cornell Modern Indonesia Collection
       cooper: "cooper*",		    # Cooper Bridge Plan Collection
       ezra: "ezra*",			      # Ezra Cornell Papers
       flo: "flo*",			        # Language of Flowers
       hearth: "hearth*",		    # Home Economics Archive: Research
       hivebees: "hivebees*",    # Hive and the Honeybee
       hunt: "hunt*",			      # Huntington Free Library Native American Collection
-      izq: "izq*",			        # History of the Left in Latin America
+      izquierda: "izquierda*",  # History of the Left in Latin America
       liber: "liber*",		    	# Liberian Law Collection
       may: "may*",			        # Samuel J. May Anti-Slavery Collection
       nur: "nur*",			        # Donovan Nuremberg Trials Collection
-      regmi: "regmi*",		      # Regmi Research Series
       sat: "sat*",			        # Trial Pamphlets Collection
       scott: "scott*",			    # Scottsboro Trials Collection
       sea: "sea*",			        # Southeast Asia Visions
@@ -193,18 +191,16 @@ class ApplicationController < ActionController::Base
       fq_dlxs += [  # include these dlxs collections
         dlxs[:bol],
         dlxs[:chla],
-        # dlxs[:cmip],
         # dlxs[:cooper],
         # dlxs[:ezra],
         dlxs[:flo],
         dlxs[:hearth],
         dlxs[:hivebees],
         dlxs[:hunt],
-        # dlxs[:izq],
+        # dlxs[:izquierda],
         # dlxs[:liber],
         # dlxs[:may],
         # dlxs[:nur],
-        # dlxs[:regmi],
         # dlxs[:sat],
         # dlxs[:scott],
         # dlxs[:sea],

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -520,12 +520,21 @@ def has_collection_selected?
   end
 end
 
-
 def asset_visible?(document)
   # eid = id.sub(':', '\:')
   if document.id.present?
-    eid = document.id
-    fq = URI.escape(@fq)
+    eid = document.id.sub(':', '\:')
+    environment = ENV['RAILS_ENV']
+    if environment == 'development'
+      # see app/controllers/application_controller.rb:100
+      # leave out the work_sequence_isi:[2 TO *] clauses to allow viewing multi-image
+      fqa = ['-active_fedora_model_ssi:"Page"',
+        '-solr_loader_tesim:"eCommons"']
+      fq = fqa.join(' AND ')
+    else
+      fq = @fq
+    end
+    fq = URI.escape(fq)
     response = JSON.parse(HTTPClient.get_content("#{ENV['SOLR_URL']}/select?q=id:#{eid}&fq=#{fq}&fl=id&wt=json&indent=true&rows=1")).with_indifferent_access
     count = response['response']['numFound']
     count > 0
@@ -533,7 +542,5 @@ def asset_visible?(document)
     false
   end
 end
-
-
 
 end

--- a/app/views/catalog/_multi_images.html.erb
+++ b/app/views/catalog/_multi_images.html.erb
@@ -7,7 +7,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 					    <img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -24,7 +24,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 							<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -59,7 +59,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -76,7 +76,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -93,7 +93,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>


### PR DESCRIPTION
* Remove the regmi collection - it is in eCommons now

* Remove cmip collection

* izq: prefix is now izquierda

* reconstruct filter query for development to allow multi-image documents to be viewed

* protect against missing titles when displaying multi-image documents

* comment for future updates