### PR TITLE
Digcoll 1670b - facet modal window links stay in the modal window

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,18 +79,16 @@ class ApplicationController < ActionController::Base
     dlxs = {
       bol: "bol*",			        # Alfredo Montalvo Bolivian Digital Pamphlets Collection
       chla: "chla*",			      # Core Historical Literature of Agriculture
-      cmip: "cmip*",			      # Cornell Modern Indonesia Collection
       cooper: "cooper*",		    # Cooper Bridge Plan Collection
       ezra: "ezra*",			      # Ezra Cornell Papers
       flo: "flo*",			        # Language of Flowers
       hearth: "hearth*",		    # Home Economics Archive: Research
       hivebees: "hivebees*",    # Hive and the Honeybee
       hunt: "hunt*",			      # Huntington Free Library Native American Collection
-      izq: "izq*",			        # History of the Left in Latin America
+      izquierda: "izquierda*",  # History of the Left in Latin America
       liber: "liber*",		    	# Liberian Law Collection
       may: "may*",			        # Samuel J. May Anti-Slavery Collection
       nur: "nur*",			        # Donovan Nuremberg Trials Collection
-      regmi: "regmi*",		      # Regmi Research Series
       sat: "sat*",			        # Trial Pamphlets Collection
       scott: "scott*",			    # Scottsboro Trials Collection
       sea: "sea*",			        # Southeast Asia Visions
@@ -193,18 +191,16 @@ class ApplicationController < ActionController::Base
       fq_dlxs += [  # include these dlxs collections
         dlxs[:bol],
         dlxs[:chla],
-        # dlxs[:cmip],
         # dlxs[:cooper],
         # dlxs[:ezra],
         dlxs[:flo],
         dlxs[:hearth],
         dlxs[:hivebees],
         dlxs[:hunt],
-        # dlxs[:izq],
+        # dlxs[:izquierda],
         # dlxs[:liber],
         # dlxs[:may],
         # dlxs[:nur],
-        # dlxs[:regmi],
         # dlxs[:sat],
         # dlxs[:scott],
         # dlxs[:sea],

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -520,12 +520,21 @@ def has_collection_selected?
   end
 end
 
-
 def asset_visible?(document)
   # eid = id.sub(':', '\:')
   if document.id.present?
-    eid = document.id
-    fq = URI.escape(@fq)
+    eid = document.id.sub(':', '\:')
+    environment = ENV['RAILS_ENV']
+    if environment == 'development'
+      # see app/controllers/application_controller.rb:100
+      # leave out the work_sequence_isi:[2 TO *] clauses to allow viewing multi-image
+      fqa = ['-active_fedora_model_ssi:"Page"',
+        '-solr_loader_tesim:"eCommons"']
+      fq = fqa.join(' AND ')
+    else
+      fq = @fq
+    end
+    fq = URI.escape(fq)
     response = JSON.parse(HTTPClient.get_content("#{ENV['SOLR_URL']}/select?q=id:#{eid}&fq=#{fq}&fl=id&wt=json&indent=true&rows=1")).with_indifferent_access
     count = response['response']['numFound']
     count > 0
@@ -533,7 +542,5 @@ def asset_visible?(document)
     false
   end
 end
-
-
 
 end

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,14 +1,14 @@
-<div class="prev_next_links btn-group">
+<div class="prev_next_links btn-group float-md-left">
   <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
-    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn' %>
+    <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
   <% end %>
 
   <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
-    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn' %>
+    <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
   <% end %>
 </div>
 
-<div class="sort-options btn-group">
+<div class="sort-options btn-group float-md-right">
   <% if @pagination.sort == 'index' -%>
     <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
     <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,10 +1,10 @@
 <div class="prev_next_links btn-group">
   <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
-    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn' %>
   <% end %>
 
   <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
-    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn' %>
   <% end %>
 </div>
 

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,17 +1,19 @@
-  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
+<div class="prev_next_links btn-group pull-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { ajax_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
   <% end %>
 
-  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { ajax_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
   <% end %>
 </div>
 
+<div class="sort-options btn-group pull-right">
   <% if @pagination.sort == 'index' -%>
     <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
-    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>
+    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-outline-secondary", data: { ajax_modal: "preserve" }) %>
   <% elsif @pagination.sort == 'count' -%>
-    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h), class: "sort_change az btn btn-outline-secondary",  data: { blacklight_modal: "preserve" }) %>
+    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h), class: "sort_change az btn btn-outline-secondary",  data: { ajax_modal: "preserve" }) %>
     <span class="active numeric btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.count') %></span>
   <% end -%>
 </div>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,4 +1,3 @@
-<div class="prev_next_links btn-group float-md-left">
   <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
   <% end %>
@@ -8,7 +7,6 @@
   <% end %>
 </div>
 
-<div class="sort-options btn-group float-md-right">
   <% if @pagination.sort == 'index' -%>
     <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
     <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,10 +1,10 @@
 <div class="prev_next_links btn-group float-md-left">
   <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
-    <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
   <% end %>
 
   <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
-    <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
   <% end %>
 </div>
 

--- a/app/views/catalog/_multi_images.html.erb
+++ b/app/views/catalog/_multi_images.html.erb
@@ -7,7 +7,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 					    <img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -24,7 +24,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 							<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -59,7 +59,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -76,7 +76,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>
@@ -93,7 +93,7 @@
 					<a href="/catalog/<%= image['id'] %>" data-turbolinks="false" aria-label="<%= image['id'] %>">
 						<img src='<%= image["media_URL_size_2_tesim"][0] %>' class="img-responsive" alt="" />
 						<span class="caption">
-							<%= image['title_tesim'][0] %>
+							<%= image['title_tesim'].present? ? image['title_tesim'][0] : '' %>
 						</span>
 					</a>
 				</div>


### PR DESCRIPTION
Uses DISCOVERYACCESS-5905 fix to remove extra </span> tag, then uses classes and data: parameter from blacklight-6.2.0 _facet_pagination.html.erb to keep the modal dialog open after prev/next and sort links.