### PR TITLE
Digcoll 1686 - multi-view excluded from index yet visible in production

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -516,6 +516,8 @@ def asset_visible?(document)
       fq = fqa.join(' AND ')
     else
       fq = @fq
+      fq.slice! '-(work_sequence_isi:[2 TO *] AND -compound_object_count_isi:1) AND'
+      fq
     end
     fq = URI.escape(fq)
     response = JSON.parse(HTTPClient.get_content("#{ENV['SOLR_URL']}/select?q=id:#{eid}&fq=#{fq}&fl=id&wt=json&indent=true&rows=1")).with_indifferent_access

--- a/features/content/content.feature
+++ b/features/content/content.feature
@@ -62,3 +62,21 @@ Examples:
 | suppressed sterrett | production | ss:12561355 |
 | suppressed artifacts | production | ss:640913 |
 
+@DIGCOLL-1686
+@content-assets-not-suppressed
+Scenario Outline: In production, only the first multiview object shows in the index, but multiview objects are available
+    Given I enable the 'production' environment
+        And I browse collection nicknamed '<nickname>'
+        And I search for asset '<asset_title>'
+        Then I should not see id '<id>' in the search results
+        And I go to asset '<id>'
+        Then the asset title field should contain '<second_title>'
+        Then I enable the 'development' environment
+
+Examples:
+    | nickname | asset_title | second_title | id | comment |
+    | impersonator | Arigon - Imitateur | Arigon - Imitateur (verso) | ss:24415885 | back of postcard |
+    | anthrocollections | Stingray spines | Stingray spines | ss:3235765 | multi-image and compound object |
+    | impersonator | Florin Imitateur | Florin Imitateur (verso) | ss:24415925 | back of postcard |
+    | anthrocollections | Hand spun cotton thread | Ball of hand spun cotton yarn | ss:1334128 | multi-image |
+

--- a/features/step_definitions/searchresults.rb
+++ b/features/step_definitions/searchresults.rb
@@ -58,3 +58,11 @@ Given("I search for everything") do
   search = URI.escape("/?utf8=✓&q=&search_field=all_fields")
   visit(search)
 end
+
+Then("I should not see id {string} in the search results") do |string|
+  link = "a[href=\"/catalog/#{string}\"]"
+  rows = page.all("div.documentHeader h5.index_title")
+  rows.each do |row|
+    expect(row).not_to have_selector(link)
+  end
+end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -80,3 +80,7 @@ end
 Then("I see the asset is suppressed") do
     expect(page.find('div#content h1')).to have_content('Item restricted')
 end
+
+Then("I see the asset is not suppressed") do
+    expect(page.find('div#content h1')).not_to have_content('Item restricted')
+end


### PR DESCRIPTION
Only the first multiview shows in index in production, but the others should be accessible.