### PR TITLE
Digcoll 1711 - hide multi-image region for single multi-image items

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -428,7 +428,7 @@ end
 
 def is_multi_image? args
   mv = get_multiviews(args)
-  mv.any?
+  mv.any? && mv.count > 1
 end
 
 def publication options={}

--- a/features/fields/image.feature
+++ b/features/fields/image.feature
@@ -121,4 +121,5 @@ Feature: Compound and Related Images
         | id | label | starting |
         | ss:2619950  | Old Catalog Number  | 870.15.3 |
         | ss:28448935 | Catalog Number | 1952.WH64.1 |
+        # the next one should be | ss:19102626 | Plan Number | 057 | but that field is suppressed
         | ss:19102626 | Title | Plan 57 |

--- a/features/fields/image.feature
+++ b/features/fields/image.feature
@@ -110,3 +110,15 @@ Feature: Compound and Related Images
     | comment | id |
     | old path format | ss:25570254 |
     | both path formats | ss:8616573 |
+
+    @DIGCOLL-1711
+    Scenario Outline: Multi-Image groups with just one member should not show the Multi-Image area on the page
+    Given I go to asset '<id>'
+        And the field labeled '<label>' should begin with '<starting>'
+        And I should not see the multiimage group region
+
+    Examples:
+        | id | label | starting |
+        | ss:2619950  | Old Catalog Number  | 870.15.3 |
+        | ss:28448935 | Catalog Number | 1952.WH64.1 |
+        | ss:19102626 | Title | Plan 57 |

--- a/features/step_definitions/asset_fields.rb
+++ b/features/step_definitions/asset_fields.rb
@@ -58,3 +58,7 @@ Then("I should see an IIIF image") do
         end
     end
 end
+
+Given("I should not see the multiimage group region") do
+    expect(page.find('div#document')).not_to have_selector("div.multi-images")
+end


### PR DESCRIPTION
Removes a div if there is just one multi-image