### PR TITLE
may styling for manuscript landing page (#1297) - merging master into dev

### DIFF
--- a/app/assets/stylesheets/collections/custom/_may-antislavery.scss
+++ b/app/assets/stylesheets/collections/custom/_may-antislavery.scss
@@ -38,6 +38,9 @@ $witchcraft-red: #932129;
 			font-size: 48px;
 		}
 	}
+	.collection-banner-may-manuscripts {
+		background-image: none;
+	}
 }
 
 // Medium devices (desktops, 992px and up)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -590,6 +590,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'rights_img_tesim', :label => 'Image Rights'
     config.add_show_field 'disclaimer_tesim', :label => 'Disclaimer'
     config.add_show_field 'serial_pub_date_range_ssi', :label => 'Publication Date Range'
+    config.add_show_field 'tocplusLinks_tesim', :label => 'Table of Contents', helper_method: :autolink_field
     if ENV["COLLECTIONS"] == "development"
       config.add_show_field 'work_sequence_isi', :label => 'Work Sequence'
     end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -441,7 +441,7 @@ end
 end
 
 def autolink_field args
-  Rails.logger.info("MIAMI = #{args}")
+ # Rails.logger.info("MIAMI = #{args}")
   if !args[:document]["collection_tesim"].nil?
    collection = args[:document]["collection_tesim"][0]
    if (collection == "Persuasive Maps: PJ Mode Collection" || collection == "Digitizing Tell en-Naṣbeh, Biblical Mizpah of Benjamin")

--- a/app/views/pages/collections/may-manuscripts/index.html.erb
+++ b/app/views/pages/collections/may-manuscripts/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, 'Samuel J. May Anti-Slavery Manuscripts Collection' %>
-<div class="collection-banner">
+<div class="collection-banner collection-banner-may collection-banner-may-manuscripts">
 	<div class="container">
 		<h2>Samuel J. May Anti-Slavery Manuscripts Collection</h2>
 	</div>
@@ -13,7 +13,7 @@
 				<%= render '/catalog/search_form', { :@collection_search => "Samuel May J. Anti-Slavery Manuscripts Collection"}  %>
 			</div>
 		</div>
-		<div class="col-sm-8 col-sm-pull-4">
+		<div class="col-sm-8 col-sm-pull-4 may-layout">
 			<p>The Cornell University Library May Anti-Slavery Manuscript Collection consists mainly of correspondence among American abolitionists, including many letters to Samuel Joseph May. Also included are May's diaries from 1859-1861 and 1865-1870; correspondence among members of May's family and the family of James Miller McKim; and some correspondence with Daniel Willard Fiske and George William Harris concerning the building of the May Anti-Slavery Collection at Cornell University. Correspondents include Lyman Abbott, John Brown, Henry Grafton Chapman, Maria Weston Chapman, David Lee Child, Lydia Maria Child, Daniel Willard Fiske, William Lloyd Garrison, D.C. Haynes, George William Harris, H.B. Holmes, Oliver Otis Howard, Oliver Johnson, Joseph May, Lucretia F. May, Samuel May Jr., Samuel Joseph May, James Miller McKim, William Forster Mitchell, Lucretia Coffin Mott, Wendell Phillips, Reuben Tomlinson, George Cabot Ward, and Theodore G. Wright.</p>
 			<p>Digitized versions available for:</p>
 			<ul>

--- a/features/collections/counts.feature
+++ b/features/collections/counts.feature
@@ -17,13 +17,13 @@ Feature: Confirm that collections have the correct number of assets
 	# | adler | 11193 |
 	| adwhite | 1364 |
 	| aerial | 3390 |
-	| ahearn | 909 |
+	| ahearn | 907 |
 	| anthrocollections | 1271 |
 	| artifacts | 1673 |
 	| bam | 2311 |
 	| bastides | 2652 |
 	| beyondtaj | 6688 |
-	| blaschka | 248 |
+	| blaschka | 251 |
 	| cast | 967 |
 	| coins | 1804 |
 	| conzo | 7616 |
@@ -66,7 +66,7 @@ Feature: Confirm that collections have the correct number of assets
 	| repsslides | 1357 |
 	| rmc | 19444 |
 	| rudin | 517 |
-	| seneca | 697 |
+	| seneca | 693 |
 	| squeezes | 369 |
 	| srilanka | 527 |
 	| stereoscopes | 213 |
@@ -79,7 +79,7 @@ Feature: Confirm that collections have the correct number of assets
     # dlxs collections
 	| bol | 30938 |
 	# | chla | 1132199 |
-	| ezra | 26256 |
+	| ezra | 559 |
 	| flow | 23590 |
 	| hivebees | 34478 |
 	#| hearth | 667340 |

--- a/features/content/content.feature
+++ b/features/content/content.feature
@@ -44,7 +44,7 @@ Examples:
 | kmoddl | production | ss:372824 |
 | leuenberger | production | ss:9469095 |
 | paniccioli | production | ss:8432316 |
-| seneca | production | ss:24767712 |
+# | seneca | production | ss:24767712 |
 | cooper | production | cooper:0107 |
 | ezra | production | ezraGene000 |
 | izquierda | production | izquierda1300_1359 |
@@ -75,7 +75,7 @@ Scenario Outline: In production, only the first multiview object shows in the in
 Examples:
     | nickname | asset_title | second_title | id | comment |
     | impersonator | Arigon - Imitateur | Arigon - Imitateur (verso) | ss:24415885 | back of postcard |
-    | anthrocollections | Stingray spines | Stingray spines | ss:3235765 | multi-image and compound object |
+    #  not multiview now | anthrocollections | Stingray spines | Stingray spines | ss:3235765 | multi-image and compound object |
     | impersonator | Florin Imitateur | Florin Imitateur (verso) | ss:24415925 | back of postcard |
-    | anthrocollections | Hand spun cotton thread | Ball of hand spun cotton yarn | ss:1334128 | multi-image |
+    #  not multiview now | anthrocollections | Hand spun cotton thread | Ball of hand spun cotton yarn | ss:1334128 | multi-image |
 

--- a/features/fields/dlxs.feature
+++ b/features/fields/dlxs.feature
@@ -26,7 +26,7 @@ Feature: Support for DLXS collections
 	| Page | chla1043101_01_100 | Subject | Agriculture |
 	| Page | chla1043101_01_100 | Extent | 424 |
 	| Series | ezra0001_1 | Title | Correspondence: June 17, 1828 - September 22, 1830 |
-	| Series | ezra0001_1 | Collection | Ezra Cornell Letters |
+	| Series | ezra0001_1 | Collection | Ezra Cornell |
 	| Series | ezra0001_1 | Extent | 35 |
 	| Book | flow1685158 | Title | Symbolorum et emblematum centuriae |
 	| Book | flow1685158 | Collection | Language of Flowers |

--- a/features/fields/image.feature
+++ b/features/fields/image.feature
@@ -25,10 +25,10 @@ Feature: Compound and Related Images
     Examples:
     | nickname | id | count |
     | impersonator | 24415896 | 1 |
-    | seneca | 22376760 | 7 |
+    | seneca | 22376760 | 6 |
     | tellennasbeh | 19102646 | 1 |
     | tellennasbeh | 19102650 | 1 |
-    | anthrocollections | 1334130 | 6 |
+    # not multi image now | anthrocollections | 1334130 | 6 |
 
     @javascript
     @multi-image
@@ -52,9 +52,9 @@ Feature: Compound and Related Images
     | obama | The end of white America? | 1282486 |
     | paniccioli | Christopher Wallace | 23019390 |
     | ragamala | Unidentified Deity | 9011771 |
-    | seneca | American beech charcoal | 22376848 |
-    | seneca | American beech charcoal | 24767699 |
-    | seneca | Marten long bone | 22376742 |
+    #  published | seneca | American beech charcoal | 22376848 |
+    #  published | seneca | American beech charcoal | 24767699 |
+    #  published | seneca | Marten long bone | 22376742 |
     # | squeezes | Latin Column 1 | 3307295 |
     # | rare | Fuegians going to trade in Zapallos | 572113 |
 
@@ -80,9 +80,9 @@ Feature: Compound and Related Images
     | obama | The end of white America? | 1282486 |
     | paniccioli | Christopher Wallace | 23019390 |
     | ragamala | Unidentified Deity | 9011771 |
-    | seneca | American beech charcoal | 22376848 |
-    | seneca | American beech charcoal | 24767699 |
-    | seneca | Marten long bone | 22376742 |
+    #  published | seneca | American beech charcoal | 22376848 |
+    #  published | seneca | American beech charcoal | 24767699 |
+    #  published | seneca | Marten long bone | 22376742 |
     # | squeezes | Latin Column 1 | 3307295 |
     # | rare | Fuegians going to trade in Zapallos | 572113 |
 


### PR DESCRIPTION
* Fix link to white springs on townley-read page

* DIGCOLL-1423: add start of may manuscripts landing page

* DIGCOLL-1067: add 'J.'

* DIGCOLL-1422: add samuel may antislavery landing page

* DIGCOLL-1423: add may styling to manuscript landing page

* added ToC field and removed MIAMI debug. (#1298)

* Digcoll 1585 - update counts and other cucumber tests (#1299)

* DIGCOLL-1585: correct collection counts

* DIGCOLL-1585: seneca items now published

* DIGCOLL-1585: these items became compound objects so multi-view tests are irrelevant

* DIGCOLL-1585: correct multi-image count

* DIGCOLL-1585: Letters or Papers start with Ezra Cornell

* added ToC field and removed MIAMI debug. (#1300)

Co-authored-by: jac244 <jac244@cornell.edu>
Co-authored-by: James Reidy <jgreidy@users.noreply.github.com>