### PR TITLE
DIGCOLL-1877 - disable facet listing page used by search engines

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   concern :searchable, Blacklight::Routes::Searchable.new
   concern :exportable, Blacklight::Routes::Exportable.new
 
+  # DIGCOLL-1877
+  get '/catalog/facet/:id(.:format)', to: redirect('/catalog/facet_list_disabled')
+
   resource :catalog, only: [:index], controller: 'catalog' do
     concerns :searchable
     concerns :range_searchable


### PR DESCRIPTION
When facet field is undefined in solr, causes AppSignal errors