### PR TITLE
Digcoll-1886 - Deliniator issue copyright limit

### DIFF
--- a/features/collections/counts.feature
+++ b/features/collections/counts.feature
@@ -18,7 +18,7 @@ Feature: Confirm that collections have the correct number of assets
 	| dlxs | chla | 1190622 | 1190622 |
 	| dlxs | ezra | 29604 | 29604 |
 	| dlxs | flow | 23718 | 23718 |
-	| dlxs | hearth | 672555 | 672555 |
+	| dlxs | hearth | 670256 | 670256 |
 	| dlxs | hivebees | 34479 | 34479 |
 	| dlxs | hunt | 33392 | 33392 |
 	| dlxs | izquierda | 0 | 2740 |

--- a/features/content/copyright.feature
+++ b/features/content/copyright.feature
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+Feature: Check the visibility of copyrighted material
+
+@copyright
+
+@DIGCOLL-1886
+Scenario Outline: Only issues before a certain year should be visible
+    Given I go to asset '<asset_id>'
+    Then the publication name should be '<title>'
+    And the first issue year shoud be '<earliest>'
+    And the last issue year shoud be '<latest>'
+
+Examples:
+    | asset_id | title | earliest | latest |
+    | hearth1891092 | The Delineator | 1878 | 1925 |
+

--- a/features/step_definitions/asset_fields.rb
+++ b/features/step_definitions/asset_fields.rb
@@ -67,3 +67,15 @@ Then("the issues listed should start in {int}") do |int|
     # /html/body/div[6]/div/div[2]/div/div[2]/div/div[1]/h3[1]
     expect(page.first('div.item-info > h3')).to have_content(int)
 end
+
+Then("the publication name should be {string}") do |string|
+    expect(page.first('div#document > div > h1')).to have_content(string)
+end
+
+Then("the first issue year shoud be {string}") do |string|
+    expect(page.first('div.item-info > h3')).to have_content(string)
+end
+
+Then("the last issue year shoud be {string}") do |string|
+    expect(page.all('div.item-info > h3').last).to have_content(string)
+end


### PR DESCRIPTION
Change collection count and test for issues of Deliniator after 1925 restricted by copyright.